### PR TITLE
Update to use Boot 2.0.0 API

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -2,8 +2,8 @@
  :source-paths #{"src"}
  :resource-paths #{"resources"}
  :dependencies '[[org.clojure/clojure "1.6.0"     :scope "provided"]
-                 [boot/core           "2.0.0-rc9" :scope "provided"]
-                 [adzerk/bootlaces    "0.1.10"     :scope "test"]])
+                 [boot/core           "2.1.2"     :scope "provided"]
+                 [adzerk/bootlaces    "0.1.10"    :scope "test"]])
 
 (require
  '[adzerk.bootlaces :refer :all]

--- a/src/jeluard/boot_notify.clj
+++ b/src/jeluard/boot_notify.clj
@@ -36,7 +36,7 @@
 
 (defn boot-logo
   []
-  (let [d (core/temp-dir!)
+  (let [d (core/tmp-dir!)
         f (io/file d "logo.png")]
     (io/copy (io/input-stream (io/resource "boot-logo-3.png")) f)
     (.getAbsolutePath f)))


### PR DESCRIPTION
I would suggest releasing this as version 0.2.0 as this breaks compatibility with Boot release candidates.
