### PR TITLE
Update for boot version 2.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Relies on [terminal-notifier](https://github.com/alloy/terminal-notifier) on OSX
 Add `boot-notify` to your `build.boot` dependencies and `require` the namespace:
 
 ```clj
-(set-env! :dependencies '[[jeluard/boot-notify "0.2.0" :scope "test"]])
+(set-env! :dependencies '[[jeluard/boot-notify "0.2.1" :scope "test"]])
 (require '[jeluard.boot-notify :refer [notify]])
 ```
 

--- a/build.boot
+++ b/build.boot
@@ -1,9 +1,8 @@
 (set-env!
  :source-paths #{"src"}
  :resource-paths #{"resources"}
- :dependencies '[[org.clojure/clojure "1.6.0"     :scope "provided"]
-                 [boot/core           "2.1.2"     :scope "provided"]
-                 [adzerk/bootlaces    "0.1.10"    :scope "test"]])
+ :dependencies '[[org.clojure/clojure "1.7.0"     :scope "provided"]
+                 [adzerk/bootlaces    "0.1.13"    :scope "test"]])
 
 (require
  '[adzerk.bootlaces :refer :all]
@@ -11,7 +10,7 @@
  '[boot.util        :as util]
  '[boot.core        :as core])
 
-(def +version+ "0.2.0")
+(def +version+ "0.2.1")
 
 (bootlaces! +version+)
 

--- a/src/jeluard/boot_notify.clj
+++ b/src/jeluard/boot_notify.clj
@@ -43,11 +43,11 @@
 
 (core/deftask notify
   "Visible notifications during build."
-  [n notifier           sym       "Custom notifier. When not provided a platform specific notifier will be used."
-   m template FOO=BAR   {kw str}  "Templates overriding default messages. Keys can be :success, :warning or :failure."
-   t title              str       "Title of the notification"
-   i icon               str       "Full path of the file used as notification icon"
-   p pid                str       "Unique ID identifying this boot process"]
+  [n notifier SYM       sym       "Custom notifier (when not provided a platform specific notifier will be used)."
+   m template FOO=BAR   {kw str}  "Templates overriding default messages (keys can be :success, :warning or :failure)."
+   t title TITLE        str       "Title of the notification."
+   i icon PATH          str       "Full path of the file used as notification icon."
+   p pid ID             str       "Unique ID identifying this boot process."]
   (let [title (or title "Boot notify")
         base-message {:title title :pid (or pid title)
                       :icon (or icon (boot-logo))}


### PR DESCRIPTION
Boot 2.5.0 throws exceptions when task options are missing optargs. Sorry for the inconvenience, this should fix it.
